### PR TITLE
Filtering out custom post types which were slipping into queries.

### DIFF
--- a/src/class.dfp_ad_position.php
+++ b/src/class.dfp_ad_position.php
@@ -105,11 +105,13 @@ class DFP_Ad_Position {
 		 * @param $position WP_Post
 		 */
 		if (
-            $id !== null &&
-            $position = get_post( $id )
-        ) {
+			(
+				$id !== null &&
+		                $position = get_post( $id )
+			) &&
+			$position->post_type === 'dfp_ads'
+	        ) {
 			$meta = get_post_meta( $position->ID );
-
 			$this->post_id      = $id;
 			$this->title        = $position->post_title;
 			$this->ad_name      = $meta['dfp_ad_code'][0];

--- a/src/helper_functions.php
+++ b/src/helper_functions.php
@@ -47,6 +47,12 @@ function dfp_get_ad_positions() {
 		endwhile;
 	}
 
+	foreach ( $positions as $key => $position ) {
+		if ( $position->post_id == NULL ) {
+			unset( $positions[$key] );
+		}
+	}
+
 	return $positions;
 }
 


### PR DESCRIPTION
Object didn't correctly filter to make sure that a CPT was "DFP_Ads" post type before creating the object. Now will correctly check post type before claiming it's a DFP_Ad.